### PR TITLE
Fix formatting of service tag

### DIFF
--- a/arm-alltypes/main.tsp
+++ b/arm-alltypes/main.tsp
@@ -16,9 +16,7 @@ using Azure.ResourceManager;
 
 /** {{parameters.ServiceNamespace}} Resource Provider management API. */
 @armProviderNamespace
-@service(#{
-  title: "{{parameters.ServiceNamespace}} management service",
-})
+@service(#{ title: "{{parameters.ServiceNamespace}} management service" })
 @versioned(Versions)
 namespace {{parameters.ServiceNamespace}};
 

--- a/arm-operations/main.tsp
+++ b/arm-operations/main.tsp
@@ -13,9 +13,7 @@ using Azure.ResourceManager;
 
 /** {{parameters.ServiceNamespace}} Resource Provider management API. */
 @armProviderNamespace
-@service(#{
-  title: "{{parameters.ServiceNamespace}} management service",
-})
+@service(#{ title: "{{parameters.ServiceNamespace}} management service" })
 @versioned({{parameters.ServiceNamespace}}.Versions)
 namespace {{parameters.ServiceNamespace}};
 


### PR DESCRIPTION
Recently TypeSpec validation for partners has been failing due to formatting issues with the service name definition in `main.tsp`.  
This change brings the name into alignment with what the validation expects.